### PR TITLE
add .0 for go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/rdma-cni
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/Mellanox/rdmamap v1.1.0


### PR DESCRIPTION
Task error: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=68362326

Hermeto errors out if its missing the `.0` for go versions >= `1.22`